### PR TITLE
Add missing dependency for pybluez

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Arch: python-pip
 Debian / Ubuntu: python3-pip
 ```
 
+* **BlueZ dev files**
+```
+Arch: bluez-libs
+Debian / Ubuntu: libbluetooth-dev
+```
+
 * **PyBluez**
 ```
 pip3 install pybluez


### PR DESCRIPTION
pybluez requires the bluez development files in order to be compiled :)