### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,13 @@ Debian / Ubuntu: python3
 * **libnotify**
 ```
 Arch: libnotify
-Debian / Ubuntu: libnotify4 gir1.2-notify-0.7
+Debian / Ubuntu: libnotify4 gir1.2-notify-0.7 gir1.2-gdkpixbuf
 ```
 
 * **python-gobject**
 ```
 Arch: python-gobject
 Debian / Ubuntu: python3-gi
-```
-
-* **gdk-pixbuf2**
-```
-Arch: gdk-pixbuf2
-Debian / Ubuntu: gir1.2-gdkpixbuf
 ```
 
 * **openssl (1.0.1+)**

--- a/README.md
+++ b/README.md
@@ -37,6 +37,12 @@ Arch: python-gobject
 Debian / Ubuntu: python3-gi
 ```
 
+* **gdk-pixbuf2**
+```
+Arch: gdk-pixbuf2
+Debian / Ubuntu: gir1.2-gdkpixbuf
+```
+
 * **openssl (1.0.1+)**
 
 ### For bluetooth:


### PR DESCRIPTION
Without gdk-pixbuf2 installed there is an error:
>Typelib file for namespace 'GdkPixbuf', version '2.0' not found