### PR TITLE
Allow notifications to be ignored if contain specific keywords

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+pygobject
+


### PR DESCRIPTION
Added ability to ignore notifications (prevent from showing) if they contain specific keywords set in the config file.

Useful if you have many devices and would rather configure it once server side rather than fiddling with the notification settings in the app on each device.

Might have it search the notificaiton message text too.