### PR TITLE
Use XDG_RUNTIME_DIR for TMP_DIR_PATH

### DIFF
--- a/an2linuxserver.py
+++ b/an2linuxserver.py
@@ -753,7 +753,8 @@ def init():
     AUTHORIZED_CERTS_PATH = os.path.join(CONF_DIR_PATH, 'authorized_certs')
     DHPARAM_PATH = os.path.join(CONF_DIR_PATH, 'dhparam.pem')
 
-    TMP_DIR_PATH = os.path.join(tempfile.gettempdir(), 'an2linux')
+    TMP_DIR_BASE = os.getenv('XDG_RUNTIME_DIR', tempfile.gettempdir())
+    TMP_DIR_PATH = os.path.join(TMP_DIR_BASE, 'an2linux')
 
     if not os.path.exists(CONF_DIR_PATH):
         os.makedirs(CONF_DIR_PATH)


### PR DESCRIPTION
Solves #41

Previous default temp folder: `$TMP/an2linux`
New default: `$XDG_RUNTIME_DIR/an2linux` (falls back to the above if XDG isnt set)

Note: I haven't tested this yet, but I don't see why it shouldn't work.